### PR TITLE
osx: target OS X 10.8 as minimum requirement (without deps)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ else
 
     ifeq ($(SYS),Darwin)
         # 10.11 El Capitan does not search for header files here by default
-        CFLAGS_c += -I/usr/local/include
+        CFLAGS_c += -I/usr/local/include -mmacosx-version-min=10.8
 
         # For re-link/deploy dynamic libraries
-        LDFLAGS_c += -headerpad_max_install_names
+        LDFLAGS_c += -headerpad_max_install_names -mmacosx-version-min=10.8
 
         # From  10.10 at least, expat is a system library
         EXPAT_CFLAGS =


### PR DESCRIPTION
Build ezquake to run on OS X 10.8 or later. This will be helpful when creating official releases or something. Note however that to make this work correctly the dependencies must be compiled with this support restriction as well (jansson/jpeg/pcre/png/sdl2).

This change should be safe. If the dependencies are not build for 10.8 it will still work as long as the target machine meets the requirements of the highest used library.