### PR TITLE
MACOS: initialize private mouse data pointer

### DIFF
--- a/in_osx.c
+++ b/in_osx.c
@@ -35,7 +35,7 @@ struct osx_mouse_data
 	int mouse_y;
 };
 
-struct osx_mouse_data *mdata;
+struct osx_mouse_data *mdata = NULL;
 
 static void input_callback(void *unused, IOReturn result, void *sender, IOHIDValueRef value)
 {


### PR DESCRIPTION
There are a lot of NULL checks, but the initial value could be anything. "dev" reported some crashes that may be caused by this.