### PR TITLE
Add "opt" to fixbundle locations

### DIFF
--- a/misc/install/fixbundle.sh
+++ b/misc/install/fixbundle.sh
@@ -54,7 +54,7 @@ if [ ! -d "$FRAMEWORK_DIR" ]; then
 fi
 
 function get_deps {
-	echo $(otool -L "$1" | grep 'local\|homebrew' | awk '{print $1}')
+	echo $(otool -L "$1" | grep 'local\|homebrew\|opt' | awk '{print $1}')
 }
 
 # readlink -f


### PR DESCRIPTION
Apparently on Apple Silicon homebrew installs itself to /opt. So we want to copy/fix libraries from there as well.